### PR TITLE
Fix recipe-maintainers to be a list

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,4 +45,4 @@ about:
 
 extra:
   recipe-maintainers:
-    jseabold
+    - jseabold


### PR DESCRIPTION
Fixes https://github.com/conda-forge/glmnet-feedstock/issues/1

Was missing the `-` necessary to treat the maintainer name as a list element. So was treating it as a list of characters instead. This fixes that issue.

cc @jseabold