### PR TITLE
BUG fix build again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   md5: {{ md5 }}
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,15 +17,14 @@ build:
 
 requirements:
   build:
-    - pip
     - python
-    - setuptools
     - numpy 1.11.*
     - scikit-learn >=0.18.0
     - scipy >=0.14.1
     - gcc
 
   run:
+    - python
     - numpy >=1.11
     - scikit-learn >=0.18.0
     - scipy >=0.14.1


### PR DESCRIPTION
So the last PR to solve the [python 3 installation](https://github.com/civisanalytics/python-glmnet/issues/33) issue did not work. 

I think the issue is that python is not set in the run dependencies. When python is not set, the package is named:

```bash
$ conda build .
BUILD START: glmnet-2.0.0-1
    (actual version deferred until further download or env creation)
```

Once you add python to the run dependencies, you get:

```bash
BUILD START: glmnet-2.0.0-py36_1
    (actual version deferred until further download or env creation)
```

I checked out the CI logs on travis for the previous build, and it appears the python 2.7 version is finishing first and then pushing itself to the cloud under the name `glmnet-2.0.0-1`. Then when the other python versions finish, they fail to push themselves to the cloud because a file by the name already exists. 

Let's try this patch.